### PR TITLE
Revert "DDPG: noise_type 'normal_x' and 'ou_x' cause assert"

### DIFF
--- a/baselines/ddpg/ddpg_learner.py
+++ b/baselines/ddpg/ddpg_learner.py
@@ -268,7 +268,7 @@ class DDPG(object):
 
         if self.action_noise is not None and apply_noise:
             noise = self.action_noise()
-            assert noise.shape == action.shape[0]
+            assert noise.shape == action.shape
             action += noise
         action = np.clip(action, self.action_range[0], self.action_range[1])
 


### PR DESCRIPTION
Reverts AurelianTactics/baselines#2